### PR TITLE
upgraded to support Akka.NET v1.2.1

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,7 @@
+#### 1.2.1 June 2017 
+
+Support for Akka 1.2.1
+
 #### 1.1.3 Februari 10 2017 ####
 
 Support for Akka 1.1.3

--- a/src/Akka.TestKit.NUnit.Tests/Akka.TestKit.NUnit.Tests.csproj
+++ b/src/Akka.TestKit.NUnit.Tests/Akka.TestKit.NUnit.Tests.csproj
@@ -32,12 +32,12 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Akka, Version=1.1.3.31, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Akka.1.1.3\lib\net45\Akka.dll</HintPath>
+    <Reference Include="Akka, Version=1.2.1.37, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Akka.1.2.1\lib\net45\Akka.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Akka.TestKit, Version=1.1.3.31, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Akka.TestKit.1.1.3\lib\net45\Akka.TestKit.dll</HintPath>
+    <Reference Include="Akka.TestKit, Version=1.2.1.37, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Akka.TestKit.1.2.1\lib\net45\Akka.TestKit.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
@@ -48,8 +48,8 @@
       <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="System.Collections.Immutable, Version=1.1.36.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Collections.Immutable.1.1.36\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+    <Reference Include="System.Collections.Immutable, Version=1.2.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Collections.Immutable.1.3.1\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Core" />

--- a/src/Akka.TestKit.NUnit.Tests/packages.config
+++ b/src/Akka.TestKit.NUnit.Tests/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Akka" version="1.1.3" targetFramework="net45" />
-  <package id="Akka.TestKit" version="1.1.3" targetFramework="net45" />
+  <package id="Akka" version="1.2.1" targetFramework="net45" />
+  <package id="Akka.TestKit" version="1.2.1" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
   <package id="NUnit" version="2.6.4" targetFramework="net45" />
-  <package id="System.Collections.Immutable" version="1.1.36" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.3.1" targetFramework="net45" />
 </packages>

--- a/src/Akka.TestKit.NUnit/Akka.TestKit.NUnit.csproj
+++ b/src/Akka.TestKit.NUnit/Akka.TestKit.NUnit.csproj
@@ -33,12 +33,12 @@
     <DocumentationFile>bin\Release\Akka.TestKit.NUnit.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Akka, Version=1.1.3.31, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Akka.1.1.3\lib\net45\Akka.dll</HintPath>
+    <Reference Include="Akka, Version=1.2.1.37, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Akka.1.2.1\lib\net45\Akka.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Akka.TestKit, Version=1.1.3.31, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Akka.TestKit.1.1.3\lib\net45\Akka.TestKit.dll</HintPath>
+    <Reference Include="Akka.TestKit, Version=1.2.1.37, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Akka.TestKit.1.2.1\lib\net45\Akka.TestKit.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
@@ -50,8 +50,8 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="System.Collections.Immutable, Version=1.1.36.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Collections.Immutable.1.1.36\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+    <Reference Include="System.Collections.Immutable, Version=1.2.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Collections.Immutable.1.3.1\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Core" />

--- a/src/Akka.TestKit.NUnit/packages.config
+++ b/src/Akka.TestKit.NUnit/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Akka" version="1.1.3" targetFramework="net45" />
-  <package id="Akka.TestKit" version="1.1.3" targetFramework="net45" />
+  <package id="Akka" version="1.2.1" targetFramework="net45" />
+  <package id="Akka.TestKit" version="1.2.1" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
   <package id="NUnit" version="2.6.4" targetFramework="net45" allowedVersions="(,3.0.0)" />
-  <package id="System.Collections.Immutable" version="1.1.36" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.3.1" targetFramework="net45" />
 </packages>

--- a/src/Akka.TestKit.NUnit3.Tests/Akka.TestKit.NUnit3.Tests.csproj
+++ b/src/Akka.TestKit.NUnit3.Tests/Akka.TestKit.NUnit3.Tests.csproj
@@ -31,12 +31,12 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Akka, Version=1.1.3.31, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Akka.1.1.3\lib\net45\Akka.dll</HintPath>
+    <Reference Include="Akka, Version=1.2.1.37, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Akka.1.2.1\lib\net45\Akka.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Akka.TestKit, Version=1.1.3.31, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Akka.TestKit.1.1.3\lib\net45\Akka.TestKit.dll</HintPath>
+    <Reference Include="Akka.TestKit, Version=1.2.1.37, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Akka.TestKit.1.2.1\lib\net45\Akka.TestKit.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
@@ -48,8 +48,8 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="System.Collections.Immutable, Version=1.1.36.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Collections.Immutable.1.1.36\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+    <Reference Include="System.Collections.Immutable, Version=1.2.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Collections.Immutable.1.3.1\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Core" />

--- a/src/Akka.TestKit.NUnit3.Tests/packages.config
+++ b/src/Akka.TestKit.NUnit3.Tests/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Akka" version="1.1.3" targetFramework="net45" />
-  <package id="Akka.TestKit" version="1.1.3" targetFramework="net45" />
+  <package id="Akka" version="1.2.1" targetFramework="net45" />
+  <package id="Akka.TestKit" version="1.2.1" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
   <package id="NUnit" version="3.4.1" targetFramework="net45" />
-  <package id="System.Collections.Immutable" version="1.1.36" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.3.1" targetFramework="net45" />
 </packages>

--- a/src/Akka.TestKit.NUnit3/Akka.TestKit.NUnit3.csproj
+++ b/src/Akka.TestKit.NUnit3/Akka.TestKit.NUnit3.csproj
@@ -31,12 +31,12 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Akka, Version=1.1.3.31, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Akka.1.1.3\lib\net45\Akka.dll</HintPath>
+    <Reference Include="Akka, Version=1.2.1.37, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Akka.1.2.1\lib\net45\Akka.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Akka.TestKit, Version=1.1.3.31, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Akka.TestKit.1.1.3\lib\net45\Akka.TestKit.dll</HintPath>
+    <Reference Include="Akka.TestKit, Version=1.2.1.37, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Akka.TestKit.1.2.1\lib\net45\Akka.TestKit.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
@@ -48,8 +48,8 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="System.Collections.Immutable, Version=1.1.36.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Collections.Immutable.1.1.36\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+    <Reference Include="System.Collections.Immutable, Version=1.2.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Collections.Immutable.1.3.1\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Core" />

--- a/src/Akka.TestKit.NUnit3/packages.config
+++ b/src/Akka.TestKit.NUnit3/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Akka" version="1.1.3" targetFramework="net45" />
-  <package id="Akka.TestKit" version="1.1.3" targetFramework="net45" />
+  <package id="Akka" version="1.2.1" targetFramework="net45" />
+  <package id="Akka.TestKit" version="1.2.1" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
   <package id="NUnit" version="3.4.1" targetFramework="net45" />
-  <package id="System.Collections.Immutable" version="1.1.36" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.3.1" targetFramework="net45" />
 </packages>

--- a/src/SharedAssemblyInfo.cs
+++ b/src/SharedAssemblyInfo.cs
@@ -4,5 +4,5 @@ using System.Reflection;
 [assembly: AssemblyCompanyAttribute("Akka.NET Team")]
 [assembly: AssemblyCopyrightAttribute("Copyright © 2013-2016 Akka.NET Team")]
 [assembly: AssemblyTrademarkAttribute("")]
-[assembly: AssemblyVersionAttribute("1.1.3.0")]
-[assembly: AssemblyFileVersionAttribute("1.1.3.0")]
+[assembly: AssemblyVersionAttribute("1.2.1.0")]
+[assembly: AssemblyFileVersionAttribute("1.2.1.0")]


### PR DESCRIPTION
cc @Silv3rcircl3 should I do a 1.2.0 release first instead? Don't think that it matters really given that there weren't any differences at all between 1.2.0 and 1.2.1 as far as the TestKit is concerned.